### PR TITLE
Do measurement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: foreman
+
+foreman:
+	date && time foreman start --no-timestamp

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -27,9 +27,9 @@ class Measurement < ApplicationRecord
       c = how_many_are_ready(packs, k8s: k8s)
 
       # Assume we get here within 5s (no, it's not really safe)
-      break if c == gho.package_count || n >= 8
+      break if c == gho.package_count || n >= 9
       puts "########### fresh packages count: #{c} (expecting #{gho.package_count}) #######"
-      sleep 4
+      sleep 7
       n += 1
     end
     puts "########### final packages count: #{c} (expecting #{gho.package_count}) #######"
@@ -44,11 +44,12 @@ class Measurement < ApplicationRecord
       gho.save!
     else
       puts "########### c (#{c}) != package_count (#{gho.package_count}) #######"
+      # FIXME: Leave a mess (someone should debug this mess)
     end
 
     while (g = k8s.get_leaves(namespace: 'default').count) > 0
       puts "########### g (#{g}) leaves left; still collecting #######"
-      sleep 5
+      sleep 3
     end
 
     puts "########### this is the end of the GithubOrg#run Health Check method #######"
@@ -99,14 +100,14 @@ class Measurement < ApplicationRecord
     else
       last = DateTime.parse(lastUpdate).to_time
       now = DateTime.now.in_time_zone.to_time
-      ready = now - last < 32
+      ready = now - last < 60
     end
   # rescue Kubeclient::ResourceNotFoundError
   #   return false
   end
 
   def self.do_measurement
-    t = DateTime.now.in_time_zone - 30
+    t = DateTime.now.in_time_zone - 64
     p = Package.where('updated_at > ?', t)
     #binding.pry
     puts "######## DOING MEASUREMENT NOW ##########"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_01_164914) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_01_141806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "git_hub_orgs", force: :cascade do |t|
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
 
   create_table "github_orgs", force: :cascade do |t|
     t.string "name"
@@ -29,7 +23,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_01_164914) do
 
   create_table "measurements", force: :cascade do |t|
     t.bigint "package_id", null: false
-    t.integer "count"
+    t.bigint "count"
     t.datetime "measured_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/kubernetes/namespaced/crds.yml
+++ b/kubernetes/namespaced/crds.yml
@@ -11,7 +11,17 @@ spec:
     kind: "Project"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha1"
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: "v1alpha1"
     schema:
       openAPIV3Schema:
         required: ["spec"]
@@ -103,7 +113,17 @@ spec:
     kind: "Leaf"
   scope: "Namespaced"
   versions:
-  - name: "v1alpha1"
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="Ready")].message
+      name: Status
+      type: string
+    name: "v1alpha1"
     schema:
       openAPIV3Schema:
         required: ["spec"]

--- a/kubernetes/namespaced/crds.yml
+++ b/kubernetes/namespaced/crds.yml
@@ -9,6 +9,8 @@ spec:
     plural: "projects"
     singular: "project"
     kind: "Project"
+    shortNames:
+    - proj
   scope: "Namespaced"
   versions:
   - additionalPrinterColumns:
@@ -111,6 +113,8 @@ spec:
     plural: "leaves"
     singular: "leaf"
     kind: "Leaf"
+    shortNames:
+    - l
   scope: "Namespaced"
   versions:
   - additionalPrinterColumns:

--- a/lib/leaf_reconciler.rb
+++ b/lib/leaf_reconciler.rb
@@ -71,7 +71,7 @@ module Leaf
       package_obj.download_count = r[:count]
       package_obj.save!
 
-      t = DateTime.now.in_time_zone
+      t = DateTime.now.in_time_zone.to_time
 
       # Fiber.schedule do
         repo_obj.run(k8s:, last_update: t)


### PR DESCRIPTION
We still are not creating the measurement, but at this point `foreman start` executes the sample, runs to completion, and quits with a successful exit status since `bundle exec ruby ./cli measure` succeeded, terminating itself and its neighbors.

This is great!

Let's add the real measurement now, and later on today hopefully schedule this somewhere, so we can start accumulating datapoints in the production database at neon dot tech. It will need a manifest, we can deploy it to Kubernetes as CronJob.

Then, Grafana can frame and chart as separate "multi frame" time series. (Maybe I can get all that in this PR today?)

https://www.google.com/search?q=grafana+postgres+multi+frame+time+series