### PR TITLE
Don't try building binaryen in our workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,6 +29,7 @@ env:
   BASE_TAG: base
   GEMS_TAG: gems
   GEM_CACHE_TAG: gem-cache
+  WABT_VERSION: 1.0.33
 
 jobs:
   release:
@@ -64,26 +65,31 @@ jobs:
         with:
           target: wasm32-wasi
 
-      - name: Install wabt (wasm-strip)
-        uses: kingdonb/setup-wabt@v1.0.4
-        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
-        with:
-          version: 1.0.33
-
-      - name: Add wabt to path (wasm-strip)
+      - name: Add local bin to path (wasm-strip, wasm-opt)
         shell: bash
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         run: |
-          cp bin/wasm-strip "$HOME/.wabt_1.0.33/bin"
-          echo "$HOME/.wabt_1.0.33/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Cache (restore) wasm-opt
+      - name: Cache (restore) wasm-opt, wasm-strip
         uses: actions/cache@v3
         id: cache
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         with:
           path: "${HOME}/.local/bin"
-          key: ${{ runner.os }}-wasm-opt
+          key: ${{ runner.os }}-wabt_${{ env.WABT_VERSION }}
+
+      - name: Install wabt (wasm-strip)
+        uses: kingdonb/setup-wabt@v1.0.4
+        if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
+        with:
+          version: ${{ env.WABT_VERSION }}
+
+      - name: Add wabt to path (wasm-strip)
+        shell: bash
+        if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
+        run: |
+          cp "$HOME/.wabt_${{ env.WABT_VERSION }}/bin" bin/wasm-strip "$HOME/.local/bin"
 
       - name: Build Binaryen (wasm-opt)
         shell: bash
@@ -96,7 +102,6 @@ jobs:
           cmake . && make
           mkdir -p "$HOME/.local/bin"
           cp bin/wasm-opt "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Build Wasm
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,6 +24,7 @@ on:
           - latest
           - gem-cache
           - gems
+          - base
 env:
   BASE_TAG: base
   GEMS_TAG: gems

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,19 +64,26 @@ jobs:
         with:
           target: wasm32-wasi
 
-      - name: Cache wasm-opt
+      - name: Install wabt (wasm-strip)
+        uses: kingdonb/setup-wabt@v1.0.4
+        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
+        with:
+          version: 1.0.33
+
+      - name: Add wabt to path (wasm-strip)
+        shell: bash
+        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
+        run: |
+          cp bin/wasm-strip "$HOME/.wabt_1.0.33/bin"
+          echo "$HOME/.wabt_1.0.33/bin" >> $GITHUB_PATH
+
+      - name: Cache (restore) wasm-opt
         uses: actions/cache@v3
         id: cache
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         with:
           path: "${HOME}/.local/bin"
           key: ${{ runner.os }}-wasm-opt
-
-      - name: Install wabt (wasm-strip)
-        uses: kingdonb/setup-wabt@v1.0.4
-        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
-        with:
-          version: 1.0.33
 
       - name: Build Binaryen (wasm-opt)
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -77,8 +77,6 @@ jobs:
           target: base
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            CACHE_IMAGE=ghcr.io/kingdonb/stats-tracker-ghcr:${{ github.event.inputs.cacheTag }}
 
       - name: Build and push gems
         uses: docker/build-push-action@v4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
           key: ${{ runner.os }}-wasm-opt
 
       - name: Install wabt (wasm-strip)
-        uses: kingdonb/setup-wabt@v1.0.3
+        uses: kingdonb/setup-wabt@v1.0.4
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         with:
           version: 1.0.33

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -72,6 +72,12 @@ jobs:
           path: "${HOME}/.local/bin"
           key: ${{ runner.os }}-wasm-opt
 
+      - name: Install wabt (wasm-strip)
+        uses: chiefbiiko/setup-wabt@v1.0.0
+        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
+        with:
+          version: 1.0.33
+
       - name: Build Binaryen (wasm-opt)
         shell: bash
         if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
@@ -84,11 +90,6 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           cp bin/wasm-opt "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-
-      - name: Install wabt (wasm-strip)
-        uses: chiefbiiko/setup-wabt@v1.0.0
-        with:
-          version: 1.0.33
 
       - name: Build Wasm
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,6 +46,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        with:
+          ruby-version: '3.1.4'
+
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
       - name: Build and push gems
         uses: docker/build-push-action@v4
         if: "${{ github.event.inputs.dockerTarget == 'gems'}}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -60,6 +60,8 @@ jobs:
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
+        with:
+          target: wasm32-wasi
 
       - name: Build Wasm
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,6 +32,9 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,6 +69,7 @@ jobs:
         shell: bash
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         run: |
+          mkdir -p "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Cache (restore) wasm-opt, wasm-strip
@@ -100,7 +101,6 @@ jobs:
           git submodule init
           git submodule update
           cmake . && make
-          mkdir -p "$HOME/.local/bin"
           cp bin/wasm-opt "$HOME/.local/bin"
 
       - name: Build Wasm

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
           key: ${{ runner.os }}-wasm-opt
 
       - name: Install wabt (wasm-strip)
-        uses: kingdonb/setup-wabt@v1.0.2
+        uses: kingdonb/setup-wabt@v1.0.3
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         with:
           version: 1.0.33

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
           key: ${{ runner.os }}-wasm-opt
 
       - name: Install wabt (wasm-strip)
-        uses: chiefbiiko/setup-wabt@v1.0.0
+        uses: kingdonb/setup-wabt@v1.0.1
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         with:
           version: 1.0.33

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@bc1dd263b68cb5626dbb55d5c89777d79372c484
         with:
           ruby-version: '3.1.4'
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -86,7 +86,7 @@ jobs:
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install wabt (wasm-strip)
-        uses: chiefbiiko/setup-wabt@1.0.0
+        uses: chiefbiiko/setup-wabt@v1.0.0
         with:
           version: 1.0.33
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,7 @@ env:
   GEMS_TAG: gems
   GEM_CACHE_TAG: gem-cache
   WABT_VERSION: 1.0.33
+  BINARYEN_VERSION: "113"
 
 jobs:
   release:
@@ -72,36 +73,39 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
-      - name: Cache (restore) wasm-opt, wasm-strip
-        uses: actions/cache@v3
-        id: cache
-        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
-        with:
-          path: "${HOME}/.local/bin"
-          key: ${{ runner.os }}-wabt_${{ env.WABT_VERSION }}
+      # - name: Cache (restore) wasm-opt, wasm-strip
+      #   uses: actions/cache@v3
+      #   id: cache
+      #   if: "${{ github.event.inputs.dockerTarget == 'base'}}"
+      #   with:
+      #     path: "${HOME}/.local/bin"
+      #     key: ${{ runner.os }}-wabt_${{ env.WABT_VERSION }}
 
-      - name: Install wabt (wasm-strip)
-        uses: kingdonb/setup-wabt@v1.0.4
-        if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
+      - name: Install wabt, binaryen
+        uses: kingdonb/setup-wabt@v1.0.5
+        if: "${{ github.event.inputs.dockerTarget == 'base' }}"
         with:
           version: ${{ env.WABT_VERSION }}
+          version2: ${{ env.BINARYEN_VERSION }}
 
-      - name: Add wabt to path (wasm-strip)
+      - name: Add to path (wasm-strip, wasm-opt)
         shell: bash
-        if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
+        if: "${{ github.event.inputs.dockerTarget == 'base' }}"
         run: |
           cp "$HOME/.wabt_${{ env.WABT_VERSION }}/bin/wasm-strip" "$HOME/.local/bin"
+          cp "$HOME/.binaryen_${{ env.BINARYEN_VERSION }}/bin/wasm-opt" "$HOME/.local/bin"
 
-      - name: Build Binaryen (wasm-opt)
-        shell: bash
-        if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
-        run: |
-          git clone https://github.com/WebAssembly/binaryen/
-          pushd binaryen
-          git submodule init
-          git submodule update
-          cmake . && make
-          cp bin/wasm-opt "$HOME/.local/bin"
+      # - name: Build Binaryen (wasm-opt)
+      #   shell: bash
+      #   if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
+      #   run: |
+      #     # git clone https://github.com/WebAssembly/binaryen/
+      #     # pushd binaryen
+      #     # git submodule init
+      #     # git submodule update
+      #     # cmake . -DCMAKE_CXX_FLAGS="-static" -DCMAKE_C_FLAGS="-static" -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC_LIB=ON && make
+      #     https://github.com/WebAssembly/binaryen/releases/download/version_113/binaryen-version_113-x86_64-linux.tar.gz
+      #     # cp bin/wasm-opt "$HOME/.local/bin"
 
       - name: Build Wasm
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -63,6 +63,27 @@ jobs:
         with:
           target: wasm32-wasi
 
+      - name: Cache wasm-opt
+        uses: actions/cache@v3
+        id: cache
+        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
+        with:
+          path: "${HOME}/.local/bin"
+          key: ${{ runner.os }}-wasm-opt
+
+      - name: Build Binaryen (wasm-opt)
+        shell: bash
+        if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
+        run: |
+          git clone https://github.com/WebAssembly/binaryen/
+          pushd binaryen
+          git submodule init
+          git submodule update
+          cmake . && make
+          mkdir -p "$HOME/.local/bin"
+          cp bin/wasm-opt "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
       - name: Build Wasm
         shell: bash
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -59,19 +59,13 @@ jobs:
 
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
 
-      - name: Build and push gems
-        uses: docker/build-push-action@v4
-        if: "${{ github.event.inputs.dockerTarget == 'gems'}}"
-        with:
-          context: .
-          push: true
-          tags: ghcr.io/kingdonb/stats-tracker-ghcr:gems
-          target: gems
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            CACHE_IMAGE=ghcr.io/kingdonb/stats-tracker-ghcr:${{ github.event.inputs.cacheTag }}
+      - name: Build Wasm
+        shell: bash
+        if: "${{ github.event.inputs.dockerTarget == 'base'}}"
+        run: |
+          make -C lib stat.wasm
 
       - name: Build and push base
         uses: docker/build-push-action@v4
@@ -81,6 +75,19 @@ jobs:
           push: true
           tags: ghcr.io/kingdonb/stats-tracker-ghcr:${{ env.BASE_TAG }}
           target: base
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            CACHE_IMAGE=ghcr.io/kingdonb/stats-tracker-ghcr:${{ github.event.inputs.cacheTag }}
+
+      - name: Build and push gems
+        uses: docker/build-push-action@v4
+        if: "${{ github.event.inputs.dockerTarget == 'gems'}}"
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/kingdonb/stats-tracker-ghcr:gems
+          target: gems
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -90,7 +90,7 @@ jobs:
         shell: bash
         if: "${{ github.event.inputs.dockerTarget == 'base' && steps.cache.outputs.cache-hit != 'true'}}"
         run: |
-          cp "$HOME/.wabt_${{ env.WABT_VERSION }}/bin" bin/wasm-strip "$HOME/.local/bin"
+          cp "$HOME/.wabt_${{ env.WABT_VERSION }}/bin/wasm-strip" "$HOME/.local/bin"
 
       - name: Build Binaryen (wasm-opt)
         shell: bash

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -73,7 +73,7 @@ jobs:
           key: ${{ runner.os }}-wasm-opt
 
       - name: Install wabt (wasm-strip)
-        uses: kingdonb/setup-wabt@v1.0.1
+        uses: kingdonb/setup-wabt@v1.0.2
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"
         with:
           version: 1.0.33

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -85,6 +85,11 @@ jobs:
           cp bin/wasm-opt "$HOME/.local/bin"
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
+      - name: Install wabt (wasm-strip)
+        uses: chiefbiiko/setup-wabt@1.0.0
+        with:
+          version: 1.0.33
+
       - name: Build Wasm
         shell: bash
         if: "${{ github.event.inputs.dockerTarget == 'base'}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN mkdir -p /usr/local/bundle /root/.cargo
 
 FROM $BASE_IMAGE AS base
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN mkdir -p /usr/local/bundle
 RUN echo "---\nBUNDLE_PATH: \"/usr/local/bundle\"" > /usr/local/bundle/config
 ENV BUNDLE_PATH /usr/local/bundle
 ENV GEM_PATH /usr/local/bundle


### PR DESCRIPTION
GHA will only provide us with amd64 runners so that's what type of binary we can expect to use, (and Binaryen provides one) - adapt the setup-wabt action to install both instead!

We don't really need to do the wasm stuff in multiple architectures of runner since our output stat.wasm is architecture independent (and will likely be compiled again later by cranelift or something else on the user side)