### PR TITLE
The End of Caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,18 +16,20 @@ docker:
 	# docker pull --platform $(PLATFORM) $(IMAGE):$(GEMS_TAG)
 	docker buildx build --push --platform $(PLATFORM) --target deploy -t $(OUTIMAGE):$(TAG) --build-arg CACHE_IMAGE=$(OUTIMAGE):$(GEMS_TAG) .
 
-gems:
-	docker pull --platform $(PLATFORM) $(IMAGE):$(GEMS_TAG)
-	docker pull --platform $(PLATFORM) $(IMAGE):$(GEM_CACHE_TAG)
-	docker buildx build --push --target gems -t $(OUTIMAGE):$(GEMS_TAG) --build-arg CACHE_IMAGE=$(IMAGE):$(GEM_CACHE_TAG) .
-
 gems-base:
 	docker pull --platform $(PLATFORM) $(IMAGE):$(BASE_TAG)
 	docker buildx build --push --target gems -t $(OUTIMAGE):$(GEMS_TAG) --build-arg CACHE_IMAGE=$(IMAGE):$(BASE_TAG) .
 
-gem-cache:
+gems:
 	docker pull --platform $(PLATFORM) $(IMAGE):$(GEMS_TAG)
-	docker buildx build --push --target gem-cache -t $(OUTIMAGE):$(GEM_CACHE_TAG) --build-arg CACHE_IMAGE=$(IMAGE):$(GEMS_TAG) .
+	docker pull --platform $(PLATFORM) $(IMAGE):$(GEM_CACHE_TAG)
+	docker buildx build --push --target gems -t $(OUTIMAGE):$(GEMS_TAG) --build-arg CACHE_IMAGE=$(OUTIMAGE):$(GEM_CACHE_TAG) .
+
+gem-cache:
+	# docker pull --platform $(PLATFORM) $(OUTIMAGE):$(GEMS_TAG)
+	docker tag $(OUTIMAGE):$(GEMS_TAG) $(OUTIMAGE):$(GEM_CACHE_TAG)
+	docker push $(OUTIMAGE):$(GEM_CACHE_TAG)
+	# docker buildx build --push --target gem-cache -t $(OUTIMAGE):$(GEM_CACHE_TAG) --build-arg CACHE_IMAGE=$(IMAGE):$(GEMS_TAG) .
 
 clean-cache:
 	docker buildx build --push --target gem-cache -t $(OUTIMAGE):$(GEM_CACHE_TAG) .

--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,29 @@
 .PHONY: foreman lib clean test all docker
-.PHONY: base gems gem-cache clean-cache
+.PHONY: base gems gem-cache clean-cache gems-base
 
 IMAGE:=ghcr.io/kingdonb/stats-tracker-ghcr
 TAG:=latest
 BASE_TAG:=base
 GEMS_TAG:=gems
 GEM_CACHE_TAG:=gem-cache
-PLATFORM:=linux/amd64
+PLATFORM:=linux/arm64
 OUTIMAGE:=kingdonb/opernator
 
 all: clean lib test
 
 docker:
-	docker pull --platform $(PLATFORM) $(IMAGE):$(BASE_TAG)
-	docker pull --platform $(PLATFORM) $(IMAGE):$(GEMS_TAG)
-	docker buildx build --push --platform $(PLATFORM) --target deploy -t $(OUTIMAGE):$(TAG) --build-arg CACHE_IMAGE=$(IMAGE):$(GEMS_TAG) .
+	# docker pull --platform $(PLATFORM) $(IMAGE):$(BASE_TAG)
+	# docker pull --platform $(PLATFORM) $(IMAGE):$(GEMS_TAG)
+	docker buildx build --push --platform $(PLATFORM) --target deploy -t $(OUTIMAGE):$(TAG) --build-arg CACHE_IMAGE=$(OUTIMAGE):$(GEMS_TAG) .
 
 gems:
 	docker pull --platform $(PLATFORM) $(IMAGE):$(GEMS_TAG)
 	docker pull --platform $(PLATFORM) $(IMAGE):$(GEM_CACHE_TAG)
 	docker buildx build --push --target gems -t $(OUTIMAGE):$(GEMS_TAG) --build-arg CACHE_IMAGE=$(IMAGE):$(GEM_CACHE_TAG) .
+
+gems-base:
+	docker pull --platform $(PLATFORM) $(IMAGE):$(BASE_TAG)
+	docker buildx build --push --target gems -t $(OUTIMAGE):$(GEMS_TAG) --build-arg CACHE_IMAGE=$(IMAGE):$(BASE_TAG) .
 
 gem-cache:
 	docker pull --platform $(PLATFORM) $(IMAGE):$(GEMS_TAG)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,38 @@ And, to provide a built-up series of examples that can help us try to use Wasm
 
 That's right, Web Assembly is being treated as an end here, not as a means.
 
+## The End
+
+When you adapt this Kubernetes Operator for your own purposes, you will likely
+start by forking this repo. Find `.github/workflows/publish.yaml` which will
+require some changes to point at your fork in order to use it independently.
+
+The GitHub Actions workflow is based on `workflow_dispatch` triggers. You are
+meant to run these four triggers in order to populate your Git repo:
+
+* target: `base` cache: `''` (blank)
+* target: `gems` cache: `base`
+* target: `gem-cache` cache: `gems`
+* target: `deploy` cache: `gem-cache`
+
+When you have populated the `gem-cache`, it is configured to be used as a cache
+by default for the `deploy` target, triggered manually (or can be reconfigured
+to build on your preferred `deploy` branch or with any tag-based trigger.)
+
+The `stat.wasm` is built into the `base` image so it is not rebuilt every time.
+This decision may need to be revisited later, but for now we don't expect our
+`stat.wasm` file to need changes very often, and it requires a lot of setup to
+build, so we think it's better to let it be cached on most builds.
+
+There is also this target, which you can use to start over when the cache has
+gotten away from you:
+
+* target: `clean-cache` cache: `''`
+
+It's not intended that users need to mess with the cache very often, but if you
+find that builds are taking longer than a couple of minutes, you might need to
+take a look at this. "And hopefully, with this PR, caching is finally solved."
+
 ## Why Web Assembly
 
 Our goal is to use Web Assembly for something because we came here to see that.

--- a/README.md
+++ b/README.md
@@ -22,14 +22,18 @@ meant to run these four triggers in order to populate your Git repo:
 * target: `base` cache: `''` (blank)
 * target: `gems` cache: `base`
 * target: `gem-cache` cache: `gems`
-* target: `deploy` cache: `gem-cache`
+* target: `deploy` cache: `gems`
 
 When you have populated the `gem-cache`, it is configured to be used as a cache
 by default for the `deploy` target, triggered manually (or can be reconfigured
 to build on your preferred `deploy` branch or with any tag-based trigger.)
 
-Typically, you'll only build `deploy` from the cache: `gem-cache`. That's why
-this one is the default.
+Typically, you'll only build `deploy` from the cache: `gems`. That's why
+this one is the default. You can also build `gems` from `gem-cache`, and vice
+versa. The `gem-cache` is used to make rebuilding `gems` itself faster.
+
+This works since when you run bundle install with a cache, only the gems that
+changed from the cache are needed.
 
 But in the beginning, when your `ghcr.io` repo is new and caches are all empty,
 you'll need to build a base image at least once. (Then populate the gems layers

--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ When you have populated the `gem-cache`, it is configured to be used as a cache
 by default for the `deploy` target, triggered manually (or can be reconfigured
 to build on your preferred `deploy` branch or with any tag-based trigger.)
 
+Typically, you'll only build `deploy` from the cache: `gem-cache`. That's why
+this one is the default.
+
+But in the beginning, when your `ghcr.io` repo is new and caches are all empty,
+you'll need to build a base image at least once. (Then populate the gems layers
+on top of it, finally consolidating the runtime dependencies away from all the
+build artifacts that need not be copied forward into the deploy image...)
+
+For anyone who has taken containers to production, this should be a somewhat
+familiar idea! And along with that, the idea that we shouldn't want to rebuild
+unnecessarily any things which have not changed, we use this multi-stage setup.
+
 The `stat.wasm` is built into the `base` image so it is not rebuilt every time.
 This decision may need to be revisited later, but for now we don't expect our
 `stat.wasm` file to need changes very often, and it requires a lot of setup to

--- a/README.md
+++ b/README.md
@@ -24,23 +24,27 @@ meant to run these four triggers in order to populate your Git repo:
 * target: `gem-cache` cache: `gems`
 * target: `deploy` cache: `gems`
 
-When you have populated the `gem-cache`, it is configured to be used as a cache
-by default for the `deploy` target, triggered manually (or can be reconfigured
-to build on your preferred `deploy` branch or with any tag-based trigger.)
+When you have populated the `gem-cache`, it is intended to be used as a cache
+by manual selection for the `gems ` target, triggered manually. This way you
+can update the gems without rebuilding everything.
 
-Typically, you'll only build `deploy` from the cache: `gems`. That's why
-this one is the default. You can also build `gems` from `gem-cache`, and vice
-versa. The `gem-cache` is used to make rebuilding `gems` itself faster.
+The `deploy` tag uses `gems` instead, which takes advantage of the native
+ordering of these layers in Docker and in the Dockerfile. Pull any of these and
+pick up where they leave off, for example `make gems-base` pulls a `base` tag.
 
-This works since when you run bundle install with a cache, only the gems that
-changed from the cache are needed.
+Typically, you'll only build `deploy` from the cache: `gems`. That's why this
+one is selected as the default. You can also build `gems` from `gem-cache`, and
+vice versa. The `gem-cache` is used to make rebuilding `gems` itself faster.
+
+When you run bundle install with a cache, only the gems that changed from the
+cache are needed. That is the design, anyway, it doesn't always work like that.
 
 But in the beginning, when your `ghcr.io` repo is new and caches are all empty,
 you'll need to build a base image at least once. (Then populate the gems layers
 on top of it, finally consolidating the runtime dependencies away from all the
 build artifacts that need not be copied forward into the deploy image...)
 
-For anyone who has taken containers to production, this should be a somewhat
+For anyone who has taken containers to production, this should hopefully be a
 familiar idea! And along with that, the idea that we shouldn't want to rebuild
 unnecessarily any things which have not changed, we use this multi-stage setup.
 


### PR DESCRIPTION
This update should describe the steps necessary to utilize the cached GitHub Actions Workflows in whatever forked setting, or most notably here in the parent fork where I'm expecting to use it.

The instructions should not be very hard, but it does of course turn out that getting the workflow right is the hardest part,

I'm tracking these commits so far in `main` leading up to being able to merge this (where workflows have to be pushed in order to be tested, as some workflows like `workflow_dispatch` only take their instructions from the `main` branch!)

* 86246f0
* 666cfcf
* 993af72
* 0bc17ed

It might take several more before this is ready to just click "build" with the defaults and get a new "deploy" target as `latest` from `main` branch, in a way where we could simply hook that up to pushes from the `main` branch to positive effect. 🤌 