### PR TITLE
Release 0.0.2

### DIFF
--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -18,7 +18,7 @@ class Measurement < ApplicationRecord
     gho = nil
     loop do
       gho = ::GithubOrg.find_by(name: project)
-      break if gho.present?
+      break if gho.present? && gho.package_count.present?
       # sleep 2
     end
 

--- a/deploy/overlays/production/kustomization.yaml
+++ b/deploy/overlays/production/kustomization.yaml
@@ -7,5 +7,7 @@ resources:
   - ../../bases/rbac
   - ../../bases/cron
   - namespace.yaml
-# transformers:
-#   - labels.yaml
+images:
+- name: ghcr.io/kingdonb/stats-tracker-ghcr
+  newName: ghcr.io/kingdonb/stats-tracker-ghcr
+  newTag: 0.0.1


### PR DESCRIPTION
Fix #27 

This release also introduces a convention, in the Production overlay (`deploy/overlays/production/`) wherein we're keeping the current release's version number:

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
namespace: default
resources:
  - ../../bases/crds
  - ../../bases/rails
  - ../../bases/rbac
  - ../../bases/cron
  - namespace.yaml
images:
- name: ghcr.io/kingdonb/stats-tracker-ghcr
  newName: ghcr.io/kingdonb/stats-tracker-ghcr
  newTag: 0.0.1
```

In addition to `config/version.yml`, we should update the version here. It may be time to create `RELEASING.md` and centralize this information, whatever knowledge is needed to push a new version.

The other necessary information that was added recently, a version setting in `version.yml` must be in sync with the version in the Git tag, else the release process will abort and fail (having published no release artifacts, other than the tag itself.)

I'm using a gem called `app_version` to help manage this, it doesn't seem to be maintained, but I think that's probably OK.