### PR TITLE
Release 0.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ set-version:
 	rake app:render
 	@next="$$(rake app:version | awk '{ print $$3 }')" && \
 	current="$(VERSION)" && \
+	echo "Replacing current version strings: $$current" && \
 	rake app:version && \
 	/usr/bin/sed -i '' "s/newTag: $$current/newTag: $$next/g" deploy/overlays/production/kustomization.yaml && \
 	echo "Version $$next set in code and manifests"

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: version-set prerel release git-status
 .PHONY: foreman lib clean test all docker
 .PHONY: base gems gem-cache clean-cache gems-base
 
@@ -8,8 +9,32 @@ GEMS_TAG:=gems
 GEM_CACHE_TAG:=gem-cache
 PLATFORM:=linux/arm64
 OUTIMAGE:=kingdonb/opernator
+VERSION:=$(shell rake app:version | awk '{ print $$3 }')
 
 all: clean lib test
+
+release: git-status
+	git tag $(VERSION)
+	git push origin $(VERSION)
+
+prerel: set-version
+
+# https://kgolding.co.uk/snippets/makefile-check-git-status/
+git-status:
+	@status=$$(git status --porcelain); \
+	if [ ! -z "$${status}" ]; \
+	then \
+		echo "Error - working directory is dirty. Commit those changes!"; \
+		exit 1; \
+	fi
+
+set-version:
+	rake app:render
+	@next="$$(rake app:version | awk '{ print $$3 }')" && \
+	current="$(VERSION)" && \
+	rake app:version && \
+	/usr/bin/sed -i '' "s/newTag: $$current/newTag: $$next/g" deploy/overlays/production/kustomization.yaml && \
+	echo "Version $$next set in code and manifests"
 
 docker:
 	# docker pull --platform $(PLATFORM) $(IMAGE):$(BASE_TAG)

--- a/config/version.yml
+++ b/config/version.yml
@@ -4,11 +4,11 @@
 # instead edit the file application/lib/templates/version.yml.erb
 
 major:        0
-minor:        0
-patch:        3
+minor:        1
+patch:        0
 # meta:		  rc.1
 # milestone:  4
-build:      226
+build:      227
 
 committer:  Kingdon Barrett
 build_date: 2023-06-27

--- a/config/version.yml
+++ b/config/version.yml
@@ -8,7 +8,7 @@ minor:        0
 patch:        3
 # meta:		  rc.1
 # milestone:  4
-build:      219
+build:      226
 
 committer:  Kingdon Barrett
 build_date: 2023-06-27

--- a/deploy/overlays/production/kustomization.yaml
+++ b/deploy/overlays/production/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
 images:
 - name: ghcr.io/kingdonb/stats-tracker-ghcr
   newName: ghcr.io/kingdonb/stats-tracker-ghcr
-  newTag: 0.0.3
+  newTag: 0.1.0

--- a/lib/templates/version.yml.erb
+++ b/lib/templates/version.yml.erb
@@ -4,8 +4,8 @@
 # instead edit the file application/lib/templates/version.yml.erb
 
 major:        0
-minor:        0
-patch:        3
+minor:        1
+patch:        0
 # meta:		  rc.1
 # milestone:  4
 build:      <%= `git rev-list HEAD|wc -l`.strip %>


### PR DESCRIPTION
This is the first release to include (via BuildKit) SBOM, provenance, and (via cosign) image signatures.

This is also the first release to publish Flux OCI manifests, also verified with cosign.

The release manifests are published from `deploy/` and they should be available immediately once the release is tagged, at:

https://github.com/kingdonb/podinfo/pkgs/container/manifests%2Fstats-tracker